### PR TITLE
Fix Garbage Collector Abuse

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -11,6 +11,8 @@
 
 package frc.robot;
 
+import edu.wpi.first.math.geometry.Translation2d;
+
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
  * constants. This class should not be used for any other purpose. All constants should be declared
@@ -22,5 +24,16 @@ package frc.robot;
 public final class Constants {
   public static class Controllers {
     public static final int DRIVER_CONTROLLER_PORT = 0;
+  }
+
+  public static class Drive {
+    /** Empty translation to prevent creating 2 Translation2ds every time the drive train stops. */
+    public static Translation2d EMPTY_TRANSLATION = new Translation2d();
+
+    /** The max speed the robot can go */
+    public static double MAX_SPEED = 1;
+
+    /** The max speed the robot can rotate */
+    public static double MAX_ANGULAR_SPEED = Math.PI / 2;
   }
 }

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -16,6 +16,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
 import java.io.File;
 import java.io.IOException;
 import swervelib.SwerveDrive;
@@ -23,9 +24,6 @@ import swervelib.parser.SwerveParser;
 
 public class Drive extends SubsystemBase {
   SwerveDrive drive;
-
-  /** Empty translation to prevent creating 2 Translation2ds per periodic run */
-  private static final Translation2d EMPTY_TRANSLATION = new Translation2d();
 
   /** Creates a new Drive. */
   public Drive() {
@@ -62,7 +60,8 @@ public class Drive extends SubsystemBase {
   }
 
   public void stop() {
-    drive.drive(EMPTY_TRANSLATION, 0, false, false, EMPTY_TRANSLATION);
+    drive.drive(
+        Constants.Drive.EMPTY_TRANSLATION, 0, false, false, Constants.Drive.EMPTY_TRANSLATION);
   }
 
   public void enterXMode() {
@@ -70,11 +69,11 @@ public class Drive extends SubsystemBase {
   }
 
   private double getMaximumSpeed() {
-    return 1; // TODO: move this to constants
+    return Constants.Drive.MAX_SPEED;
   }
 
   private double getMaximumAngularSpeed() {
-    return Math.PI / 2; // TODO: move this to constants
+    return Constants.Drive.MAX_ANGULAR_SPEED;
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -24,6 +24,9 @@ import swervelib.parser.SwerveParser;
 public class Drive extends SubsystemBase {
   SwerveDrive drive;
 
+  /** Empty translation to prevent creating 2 Translation2ds per periodic run */
+  private static final Translation2d EMPTY_TRANSLATION = new Translation2d();
+
   /** Creates a new Drive. */
   public Drive() {
     /* Try-catch because otherwise the compiler tries to anticipate runtime errors and throws a
@@ -59,7 +62,7 @@ public class Drive extends SubsystemBase {
   }
 
   public void stop() {
-    drive.drive(new Translation2d(), 0, false, false, new Translation2d());
+    drive.drive(EMPTY_TRANSLATION, 0, false, false, EMPTY_TRANSLATION);
   }
 
   public void enterXMode() {


### PR DESCRIPTION
Fix the redundant creation of an empty Translation2d. Unfortunately due to the immutability of Translation2d, this is all I could do without doing gross reflection stuff that would cause more of the issue this attempts to fix.

Closes #5 