### PR TITLE
Pneumatics bypass

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -145,7 +145,7 @@ public class RobotContainer {
     driverController.y().onTrue(fireNote);
     driverController.a().onTrue(runIntake);
     driverController.rightTrigger().onTrue(deployMailbox);
-    driverController.b().onTrue(fireNoteRoutineNoLimitSwitch);
+    driverController.b().whileTrue(runBelts);
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -142,9 +142,9 @@ public class RobotContainer {
     driverController.leftStick().toggleOnTrue(driveFieldOriented);
 
     driverController.x().onTrue(enterXMode);
-    driverController.y().onTrue(fireNote);
-    driverController.a().onTrue(runIntake);
-    driverController.rightTrigger().onTrue(deployMailbox);
+    driverController.y().whileTrue(fireNote);
+    driverController.a().whileTrue(runIntake);
+    driverController.rightTrigger().whileTrue(deployMailbox);
     driverController.b().whileTrue(runBelts);
   }
 


### PR DESCRIPTION
Closes #55 and closes #57.

I just took the button binding we used to use for the `fireNoteNoLimitSwitch` routine and changed it to just run the belts instead, since that will do the same thing as `fireNoteNoLimitSwitch` except it won't touch pneumatics.

I also changed the `onTrue`s to `whileTrue`s for the commands that we needed to do that with.