### PR TITLE
Swerve boost

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -81,10 +81,10 @@ public final class Constants {
     /** Empty translation to prevent creating 2 Translation2ds every time the drive train stops. */
     public static Translation2d EMPTY_TRANSLATION = new Translation2d();
 
-    /** The max speed the robot can go in autonomous in m/s */
+    /** The max speed the robot can go in m/s */
     public static double MAX_SPEED = 2;
 
-    /** The max speed the robot can rotate in autonomous */
+    /** The max speed the robot can rotate */
     public static double MAX_ANGULAR_SPEED = Math.PI;
 
     /** The distance from the center of the robot to any of the swerve modules. */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -81,10 +81,10 @@ public final class Constants {
     /** Empty translation to prevent creating 2 Translation2ds every time the drive train stops. */
     public static Translation2d EMPTY_TRANSLATION = new Translation2d();
 
-    /** The max speed the robot can go in m/s */
+    /** The max speed the robot can go in autonomous in m/s */
     public static double MAX_SPEED = 2;
 
-    /** The max speed the robot can rotate */
+    /** The max speed the robot can rotate in autonomous */
     public static double MAX_ANGULAR_SPEED = Math.PI;
 
     /** The distance from the center of the robot to any of the swerve modules. */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -13,6 +13,7 @@ package frc.robot;
 
 import com.pathplanner.lib.util.PIDConstants;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.util.Units;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -81,8 +82,11 @@ public final class Constants {
     /** Empty translation to prevent creating 2 Translation2ds every time the drive train stops. */
     public static Translation2d EMPTY_TRANSLATION = new Translation2d();
 
-    /** The max speed the robot can go in m/s */
-    public static double MAX_SPEED = 2;
+    /** The MAXIMUM possible speed for our robot. We cannot go above this. */
+    public static double MAX_SPEED_LIMIT = Units.feetToMeters(14.5);
+
+    /** The max speed we want the robot can go in m/s */
+    public static double MAX_NORMAL_SPEED = 2;
 
     /** The max speed the robot can rotate */
     public static double MAX_ANGULAR_SPEED = Math.PI;

--- a/src/main/java/frc/robot/commands/drive/DriveBoost.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBoost.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.drive;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotContainer;
+import frc.robot.subsystems.Drive;
+
+public class DriveBoost extends Command {
+
+  private final Drive drive;
+
+  /** Creates a new DriveBoost. */
+  public DriveBoost() {
+
+    this.drive = RobotContainer.drive;
+    addRequirements(drive);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/drive/DriveBoost.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBoost.java
@@ -5,6 +5,7 @@
 package frc.robot.commands.drive;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.subsystems.Drive;
 
@@ -21,7 +22,9 @@ public class DriveBoost extends Command {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    drive.setMaximumSpeed(Constants.Drive.MAX_SPEED_LIMIT);
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
@@ -29,7 +32,9 @@ public class DriveBoost extends Command {
 
   // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) {}
+  public void end(boolean interrupted) {
+    drive.setMaximumSpeed(Constants.Drive.MAX_NORMAL_SPEED);
+  }
 
   // Returns true when the command should end.
   @Override

--- a/src/main/java/frc/robot/commands/drive/DriveBoost.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBoost.java
@@ -9,6 +9,9 @@ import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.subsystems.Drive;
 
+/**
+ * Command that sets the robot's max speed to a much higher number. 
+ */
 public class DriveBoost extends Command {
 
   private final Drive drive;

--- a/src/main/java/frc/robot/commands/drive/DriveBoost.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBoost.java
@@ -2,6 +2,13 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+/*
+ * Asimov's Laws:
+ * The First Law: A robot may not injure a human being or, through inaction, allow a human being to come to harm.
+ * The Second Law: A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
+ * The Third Law: A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+ */
+
 package frc.robot.commands.drive;
 
 import edu.wpi.first.wpilibj2.command.Command;
@@ -9,9 +16,7 @@ import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.subsystems.Drive;
 
-/**
- * Command that sets the robot's max speed to a much higher number. 
- */
+/** Command that sets the robot's max speed to a much higher number. */
 public class DriveBoost extends Command {
 
   private final Drive drive;

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -35,7 +35,7 @@ public class Drive extends SubsystemBase {
   /** Creates a new Drive. */
   public Drive() {
 
-    this.maxSpeed = Constants.Drive.MAX_SPEED;
+    this.maxSpeed = Constants.Drive.MAX_NORMAL_SPEED;
 
     /* Try-catch because otherwise the compiler tries to anticipate runtime errors and throws a
      * compiletime error for a missing file even though it shouldn't
@@ -62,7 +62,7 @@ public class Drive extends SubsystemBase {
             /* HolonomicPathFollowerConfig, this should likely live in your Constants class */
             Constants.Drive.TRANSLATION_DRIVE_PID, /* Translation PID constants */
             Constants.Drive.ROTATION_DRIVE_PID, /* Rotation PID constants */
-            Constants.Drive.MAX_SPEED, /* Max module speed, in m/s */
+            Constants.Drive.MAX_NORMAL_SPEED, /* Max module speed, in m/s */
             Constants.Drive
                 .DISTANCE_ROBOT_CENTER_TO_SWERVE_MODULE, /* Drive base radius in meters. Distance from robot center to furthest module. */
             new ReplanningConfig() /* Default path replanning config. See the API for the options here */),
@@ -120,7 +120,7 @@ public class Drive extends SubsystemBase {
    * @return Maximum speed the robot chassis can achieve in m/s.
    */
   public double getMaximumSpeed() {
-    return Math.min(drive.getMaximumVelocity(), Math.min(Constants.Drive.MAX_SPEED, maxSpeed));
+    return Math.min(drive.getMaximumVelocity(), Math.max(Constants.Drive.MAX_NORMAL_SPEED, maxSpeed));
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -16,7 +16,6 @@ import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
 import com.pathplanner.lib.util.ReplanningConfig;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -43,7 +43,7 @@ public class Drive extends SubsystemBase {
     try {
       drive =
           new SwerveParser(new File(Filesystem.getDeployDirectory(), "swerve"))
-              .createSwerveDrive(Units.feetToMeters(14.5));
+              .createSwerveDrive(Constants.Drive.MAX_SPEED_LIMIT);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -30,9 +30,13 @@ import swervelib.parser.SwerveParser;
 /** The subsystem that represents the drivetrain. */
 public class Drive extends SubsystemBase {
   private SwerveDrive drive;
+  private double maxSpeed;
 
   /** Creates a new Drive. */
   public Drive() {
+
+    this.maxSpeed = Constants.Drive.MAX_SPEED;
+
     /* Try-catch because otherwise the compiler tries to anticipate runtime errors and throws a
      * compiletime error for a missing file even though it shouldn't
      */
@@ -46,7 +50,7 @@ public class Drive extends SubsystemBase {
     /* setting the motors to brake mode */
     drive.setMotorIdleMode(true);
 
-    /* Configure AutoBuilder last */
+    /* Configure AutoBuilder */
     AutoBuilder.configureHolonomic(
         this.drive::getPose, /* Robot pose supplier */
         this.drive
@@ -111,21 +115,30 @@ public class Drive extends SubsystemBase {
   }
 
   /**
-   * Gets the maximum speed the robot chassis can acheive in m/s.
+   * Gets the maximum speed the robot chassis can achieve in m/s.
    *
-   * @return Maximum speed the robot chassis can acheive in m/s.
+   * @return Maximum speed the robot chassis can achieve in m/s.
    */
   public double getMaximumSpeed() {
-    return Math.min(drive.getMaximumVelocity(), Constants.Drive.MAX_SPEED);
+    return Math.min(drive.getMaximumVelocity(), Math.min(Constants.Drive.MAX_SPEED, maxSpeed));
   }
 
   /**
-   * Gets the maximum angular speed the robot chassis can acheive in rad/s.
+   * Gets the maximum angular speed the robot chassis can achieve in rad/s.
    *
-   * @return Maximum angular speed the robot chassis can acheive in rad/s.
+   * @return Maximum angular speed the robot chassis can achieve in rad/s.
    */
   public double getMaximumAngularSpeed() {
     return Math.min(drive.getMaximumAngularVelocity(), Constants.Drive.MAX_ANGULAR_SPEED);
+  }
+
+  /**
+   * Sets the maximum speed the robot chassis can achieve in m/s.
+   *
+   * @param speed New maximum speed for the robot in m/s.
+   */
+  public void setMaximumSpeed(double speed) {
+    this.maxSpeed = speed;
   }
 
   /**
@@ -157,7 +170,7 @@ public class Drive extends SubsystemBase {
         headingX,
         headingY,
         drive.getPose().getRotation().getRadians(),
-        Constants.Drive.MAX_SPEED);
+        maxSpeed);
   }
 
   /** Runs every scheduler run. */

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -120,7 +120,7 @@ public class Drive extends SubsystemBase {
    * @return Maximum speed the robot chassis can achieve in m/s.
    */
   public double getMaximumSpeed() {
-    return Math.min(drive.getMaximumVelocity(), Math.max(Constants.Drive.MAX_NORMAL_SPEED, maxSpeed));
+    return Math.min(drive.getMaximumVelocity(), maxSpeed);
   }
 
   /**


### PR DESCRIPTION
Sets the swerve max drive speed to a much higher number (A little over double the normal max). This will increase the robot's acceleration, but also might require the drivers to be more wary due to the increased max speed. If this needs changed, let me know.