### PR TITLE
Disabled mailbox limit switch

### DIFF
--- a/src/main/java/frc/robot/commands/mailbox/DeindexNote.java
+++ b/src/main/java/frc/robot/commands/mailbox/DeindexNote.java
@@ -37,13 +37,15 @@ public class DeindexNote extends Command {
   @Override
   public void execute() {
     /* If the mailbox is fully raised, run the intake. */
-    if (mailbox.getLimitSwitch()) {
-      intake.runIntake();
-    }
-    /* This else isn't neccessary, just advised for safety. If it interferes with anything, feel free to remove it. */
-    else {
-      intake.stop();
-    }
+    // if (mailbox.getLimitSwitch()) {
+    //   intake.runIntake();
+    // }
+    // /* This else isn't neccessary, just advised for safety. If it interferes with anything, feel
+    // free to remove it. */
+    // else {
+    //   intake.stop();
+    // }
+    intake.runIntake();
   }
 
   // Called once the command ends or is interrupted.


### PR DESCRIPTION
Isn't currently installed on the robot, won't be before Heartland. Commented out code so that if we add it back after Heartland, we can add it back in code as well