### PR TITLE
Add a delay between DeployMailbox and RunIntake

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -31,7 +31,7 @@ public final class Constants {
     public static final int MAILBOX_LIMIT_SWITCH_DIO_PORT = 0;
 
     /** The delay between raising the mailbox and firing the note. In seconds. */
-    public static final double FIRE_NODE_DELAY_TIME = 0.25;
+    public static final double FIRE_NOTE_DELAY_TIME = 0.25;
   }
 
   /** Constants for the Pneumatics system. */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,6 +29,9 @@ public final class Constants {
     // It was me, DIO!
     /** DIO Port ID for the Mailbox limit switch. */
     public static final int MAILBOX_LIMIT_SWITCH_DIO_PORT = 0;
+
+    /** The delay between raising the mailbox and firing the note. In seconds. */
+    public static final double FIRE_NODE_DELAY_TIME = 0.25;
   }
 
   /** Constants for the Pneumatics system. */

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutine.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutine.java
@@ -24,7 +24,7 @@ public class FireNoteRoutine extends ParallelCommandGroup {
   public FireNoteRoutine() {
     addCommands(
         new DeployMailbox(),
-        new WaitCommand(Constants.Mailbox.FIRE_NODE_DELAY_TIME),
+        new WaitCommand(Constants.Mailbox.FIRE_NOTE_DELAY_TIME),
         new DeindexNote());
   }
 }

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutine.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutine.java
@@ -12,6 +12,8 @@
 package frc.robot.commands.mailbox;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.robot.Constants;
 
 /**
  * Scores the note into the amp. Raises the mailbox, runs the mailbox belts, and then runs the index
@@ -20,6 +22,9 @@ import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 public class FireNoteRoutine extends ParallelCommandGroup {
   /** Creates a new FireNote. */
   public FireNoteRoutine() {
-    addCommands(new DeployMailbox(), new DeindexNote());
+    addCommands(
+        new DeployMailbox(),
+        new WaitCommand(Constants.Mailbox.FIRE_NODE_DELAY_TIME),
+        new DeindexNote());
   }
 }

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
@@ -18,8 +18,8 @@ import frc.robot.commands.RunIntake;
  * Scores the note into the amp. Raises the mailbox, runs the mailbox belts, and then runs the index
  * belts to send the note into the belts without a limit switch.
  *
- * @deprecated This class does not work consistantly when there is an intake limit switch present,
- *     which will be present for the forseeable future.
+ * @deprecated This class does not work consistently when there is an intake limit switch present,
+ *     which will be present for the foreseeable future.
  */
 @Deprecated
 public class FireNoteRoutineNoLimitSwitch extends ParallelCommandGroup {

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
@@ -17,6 +17,9 @@ import frc.robot.commands.RunIntake;
 /**
  * Scores the note into the amp. Raises the mailbox, runs the mailbox belts, and then runs the index
  * belts to send the note into the belts without a limit switch.
+ *
+ * @deprecated This class does not work consistantly when there is an intake limit switch present,
+ *     which will be present for the forseeable future.
  */
 @Deprecated
 public class FireNoteRoutineNoLimitSwitch extends ParallelCommandGroup {

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
@@ -12,6 +12,8 @@
 package frc.robot.commands.mailbox;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.robot.Constants;
 import frc.robot.commands.RunIntake;
 
 /**
@@ -21,6 +23,9 @@ import frc.robot.commands.RunIntake;
 public class FireNoteRoutineNoLimitSwitch extends ParallelCommandGroup {
   /** Creates a new FireNoteRoutineNoLimitSwitch. */
   public FireNoteRoutineNoLimitSwitch() {
-    addCommands(new DeployMailbox(), new RunIntake());
+    addCommands(
+        new DeployMailbox(),
+        new WaitCommand(Constants.Mailbox.FIRE_NODE_DELAY_TIME),
+        new RunIntake());
   }
 }

--- a/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
+++ b/src/main/java/frc/robot/commands/mailbox/FireNoteRoutineNoLimitSwitch.java
@@ -12,20 +12,16 @@
 package frc.robot.commands.mailbox;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
-import frc.robot.Constants;
 import frc.robot.commands.RunIntake;
 
 /**
  * Scores the note into the amp. Raises the mailbox, runs the mailbox belts, and then runs the index
  * belts to send the note into the belts without a limit switch.
  */
+@Deprecated
 public class FireNoteRoutineNoLimitSwitch extends ParallelCommandGroup {
   /** Creates a new FireNoteRoutineNoLimitSwitch. */
   public FireNoteRoutineNoLimitSwitch() {
-    addCommands(
-        new DeployMailbox(),
-        new WaitCommand(Constants.Mailbox.FIRE_NODE_DELAY_TIME),
-        new RunIntake());
+    addCommands(new DeployMailbox(), new RunIntake());
   }
 }


### PR DESCRIPTION
closes #127 

Add a delay between DeployMailbox and RunIntake because there isn't a limit switch anymore.