### PR TITLE
JavaDoc cleanup

### DIFF
--- a/src/main/java/frc/robot/Controllers.java
+++ b/src/main/java/frc/robot/Controllers.java
@@ -62,6 +62,7 @@ public final class Controllers {
   public static Supplier<Boolean> headingSnappingLeftSupplier =
       () -> rawPilotController.getPOV() == 270;
 
+  /** Shuffleboard (NT) entry for the keymap selector */
   public static GenericEntry keymapEntry =
       Shuffleboard.getTab("Driver").add("Keymap", "Default").getEntry();
 

--- a/src/main/java/frc/robot/commands/drive/DriveFieldOrientedHeadingSnapping.java
+++ b/src/main/java/frc/robot/commands/drive/DriveFieldOrientedHeadingSnapping.java
@@ -21,7 +21,7 @@ import swervelib.SwerveController;
 
 /**
  * Drives robot in field oriented mode with shortcuts to snap to field relative angles in increments
- * of 90º using dpad
+ * of 90 degrees using dpad
  */
 public class DriveFieldOrientedHeadingSnapping extends Command {
   private Drive drive;


### PR DESCRIPTION
Removed build-breaking degree symbol in `DriveFieldOrientedHeadingSnapping` and added a comment to `Controllers#keymapEntry`. Closes #139.