### PR TITLE
re-abstract Limelight subsystem

### DIFF
--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -66,12 +66,11 @@ public class Limelight extends SubsystemBase {
             .subscribe(defaultBotpos);
 
     Shuffleboard.getTab("Driver")
-        .add(SendableCameraWrapper.wrap("Limelight", "http://10.9.37.5:5800/stream.mjpg"))
+        .add(SendableCameraWrapper.wrap(name, "http://" + name + ".local:5800/stream.mjpg"))
         .withSize(4, 4);
 
     /* TODO: CONSTANTS */
-    limelightHasTarget =
-        Shuffleboard.getTab("Driver").add("limelight has target", false).getEntry();
+    limelightHasTarget = Shuffleboard.getTab("Driver").add(name + "has target", false).getEntry();
   }
 
   /* now its time for getter method chaingun, which I have to write manually because VS Code */
@@ -165,8 +164,6 @@ public class Limelight extends SubsystemBase {
   /** Subsystem periodic; runs every scheduler run. */
   @Override
   public void periodic() {
-    // This method will be called once per scheduler run
-
     limelightHasTarget.setBoolean(hasValidTarget());
   }
 }


### PR DESCRIPTION
Closes #145. Also deleted a random comment that was auto-generated by WPILib. Uses the given Limelight's mDNS name (derived from the NetworkTables name) to grab the CameraServer stream and push it up to Shuffleboard. Also specifies which Limelight it's talking about in the limelightHasTarget Shuffleboard entry.