### PR TITLE
Heading snapping

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -14,6 +14,7 @@ package frc.robot.subsystems;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
 import com.pathplanner.lib.util.ReplanningConfig;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.util.Units;
@@ -179,6 +180,10 @@ public class Drive extends SubsystemBase {
    */
   public void setDriveMode(String driveMode) {
     driveLabelEntry.setString(driveMode);
+  }
+
+  public Rotation2d getHeading() {
+    return drive.getPose().getRotation();
   }
 
   /** Runs every scheduler run. */


### PR DESCRIPTION
*Should* fix issue #149, but needs testing. Added a thing that sets the desired heading to the heading set by the joystick when we control in joystick mode. Based off of the [YAGSL example implementation](https://github.com/BroncBotz3481/YAGSL-Example/blob/main/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java).