### PR TITLE
Miscellaneous testing fixes

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -285,7 +285,7 @@ public class RobotContainer {
 
     startIntakeCamera.schedule();
 
-    drive.setDefaultCommand(driveFieldOriented);
+    drive.setDefaultCommand(driveFieldOrientedHeadingSnapping);
   }
 
   private void configureAuto() {

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -70,7 +70,7 @@ public class Drive extends SubsystemBase {
             /* HolonomicPathFollowerConfig, this should likely live in your Constants class */
             Constants.Drive.TRANSLATION_DRIVE_PID, /* Translation PID constants */
             Constants.Drive.ROTATION_DRIVE_PID, /* Rotation PID constants */
-            Constants.Drive.MAX_SPEED, /* Max module speed, in m/s */
+            getMaximumSpeed(), /* Max module speed, in m/s */
             Constants.Drive
                 .DISTANCE_ROBOT_CENTER_TO_SWERVE_MODULE, /* Drive base radius in meters. Distance from robot center to furthest module. */
             new ReplanningConfig() /* Default path replanning config. See the API for the options here */),

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -168,7 +168,7 @@ public class Drive extends SubsystemBase {
         headingX,
         headingY,
         drive.getPose().getRotation().getRadians(),
-        Constants.Drive.MAX_SPEED);
+        getMaximumSpeed());
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -51,7 +51,7 @@ public class Intake extends SubsystemBase {
     intakeLower.burnFlash();
     intakeUpper.burnFlash();
 
-    Shuffleboard.getTab("Driver").add("Note in intake", false).getEntry();
+    noteIsInIntake = Shuffleboard.getTab("Driver").add("Note in intake", false).getEntry();
   }
 
   /** Runs the intake motors. */

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -21,7 +21,6 @@ import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.networktables.DoubleTopic;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.shuffleboard.SendableCameraWrapper;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -65,9 +64,9 @@ public class Limelight extends SubsystemBase {
             .getDoubleArrayTopic(fmtPath("botpose"))
             .subscribe(defaultBotpos);
 
-    Shuffleboard.getTab("Driver")
-        .add(SendableCameraWrapper.wrap(name, "http://" + name + ".local:5800/stream.mjpg"))
-        .withSize(4, 4);
+    /* Shuffleboard.getTab("Driver")
+    .add(SendableCameraWrapper.wrap(name, "http://" + name + ".local:5800/stream.mjpg"))
+    .withSize(4, 4); */
 
     /* TODO: CONSTANTS */
     limelightHasTarget = Shuffleboard.getTab("Driver").add(name + "has target", false).getEntry();


### PR DESCRIPTION
- Use correct methods to get the maximum drivetrain speed
- Use heading snapping mode by default
- Fix setting the state of note in intake
- Got rid of Shuffleboard Limelight feed