### PR TITLE
Update Pneumatics Code to Use Spikes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -232,6 +232,6 @@ public final class Constants {
   /** The constants for the Compressor */
   public static final class Compressor {
     public static final int PRESSURE_SWITCH_DIO_PORT = 0;
-    public static final int COMPRESSOR_RELAY_PORT = 0;
+    public static final int COMPRESSOR_RELAY_PORT = 1;
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -37,17 +37,11 @@ public final class Constants {
 
   /** Constants for the Pneumatics system. */
   public static final class MailboxPneumatics {
-    /** The channel on the PCM for the forward direction on the left solenoid. */
-    public static final int LEFT_SOLENOID_FORWARD_CHANNEL = 5;
+    /** The ID for the left solenoid relay */
+    public static final int LEFT_SOLENOID_RELAY_ID = 0;
 
-    /** The channel on the PCM for the reverse direction on the left solenoid. */
-    public static final int LEFT_SOLENOID_REVERSE_CHANNEL = 4;
-
-    /** The channel on the PCM for the forward direction on the right solenoid. */
-    public static final int RIGHT_SOLENOID_FORWARD_CHANNEL = 7;
-
-    /** The channel on the PCM for the reverse direction on the right solenoid. */
-    public static final int RIGHT_SOLENOID_REVERSE_CHANNEL = 6;
+    /** The ID for the right solenoid relay */
+    public static final int RIGHT_SOLENOID_RELAY_ID = 0;
   }
 
   /** Constants for the Belts system. */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -37,11 +37,8 @@ public final class Constants {
 
   /** Constants for the Pneumatics system. */
   public static final class MailboxPneumatics {
-    /** The ID for the left solenoid relay */
-    public static final int LEFT_SOLENOID_RELAY_ID = 0;
-
-    /** The ID for the right solenoid relay */
-    public static final int RIGHT_SOLENOID_RELAY_ID = 0;
+    /** The ID for the relay that controls the mailbox's solenoids */
+    public static final int MAILBOX_SOLENOID_RELAY_ID = 0;
   }
 
   /** Constants for the Belts system. */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -234,4 +234,10 @@ public final class Constants {
     /** The camera id for the intake camera. */
     public static final int INTAKE_CAMERA_ID = 0;
   }
+
+  /** The constants for the Compressor */
+  public static final class Compressor {
+    public static final int PRESSURE_SWITCH_DIO_PORT = 0;
+    public static final int COMPRESSOR_RELAY_PORT = 0;
+  }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -231,7 +231,16 @@ public final class Constants {
 
   /** The constants for the Compressor */
   public static final class Compressor {
-    public static final int PRESSURE_SWITCH_DIO_PORT = 0;
-    public static final int COMPRESSOR_RELAY_PORT = 1;
+    /** The DIO port for the pressure switch. */
+    public static final int PRESSURE_SWITCH_DIO_PORT = 9;
+
+    /** The relay port for the compressor */
+    public static final int COMPRESSOR_RELAY_PORT = 0;
+
+    /**
+     * How many periodic loops do we want to wait for to turn off the compressor. Used to prevent
+     * rapidly turning on and off the compressor.
+     */
+    public static final int COMPRESSOR_PRESSURE_SWITCH_DEADBAND = 100;
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -238,6 +238,6 @@ public final class Constants {
      * How many periodic loops do we want to wait for to turn off the compressor. Used to prevent
      * rapidly turning on and off the compressor.
      */
-    public static final int COMPRESSOR_PRESSURE_SWITCH_DEADBAND = 100;
+    public static final int COMPRESSOR_PRESSURE_SWITCH_DEADBAND = 100; /* = 2 Seconds */
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -101,6 +101,7 @@ public class RobotContainer {
   /** Singleton instance of the intake {@link Camera} for the whole robot. */
   public static Camera intakeCamera = new Camera(Constants.Camera.INTAKE_CAMERA_ID);
 
+  /** Singleton instance of the intake {@link Compressor} for the whole robot. */
   public static Compressor compressor = new Compressor();
 
   /*
@@ -261,6 +262,7 @@ public class RobotContainer {
   /** Singleton instance of {@link ZeroGyro} for the whole robot. */
   public static ZeroGyro zeroGyro = new ZeroGyro();
 
+  /** Singleton instance of {@link ControlCompressor} for the whole robot. */
   public static ControlCompressor controlCompressor = new ControlCompressor();
 
   /*

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,6 +23,7 @@ import frc.robot.commands.AimWithLimelight;
 import frc.robot.commands.ClearPDPStickyFaults;
 import frc.robot.commands.ClimbDown;
 import frc.robot.commands.ClimbUp;
+import frc.robot.commands.ControlCompressor;
 import frc.robot.commands.DeployUrMom;
 import frc.robot.commands.EnterXMode;
 import frc.robot.commands.RunIntake;
@@ -45,6 +46,7 @@ import frc.robot.commands.mailbox.FireNoteRoutineNoLimitSwitch;
 import frc.robot.commands.mailbox.RunBelts;
 import frc.robot.subsystems.Camera;
 import frc.robot.subsystems.Climber;
+import frc.robot.subsystems.Compressor;
 import frc.robot.subsystems.Drive;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Limelight;
@@ -98,6 +100,8 @@ public class RobotContainer {
 
   /** Singleton instance of the intake {@link Camera} for the whole robot. */
   public static Camera intakeCamera = new Camera(Constants.Camera.INTAKE_CAMERA_ID);
+
+  public static Compressor compressor = new Compressor();
 
   /*
    * ************
@@ -257,6 +261,8 @@ public class RobotContainer {
   /** Singleton instance of {@link ZeroGyro} for the whole robot. */
   public static ZeroGyro zeroGyro = new ZeroGyro();
 
+  public static ControlCompressor controlCompressor = new ControlCompressor();
+
   /*
    * ***********************
    * * OTHER INSTANCE VARS *
@@ -286,6 +292,7 @@ public class RobotContainer {
     startIntakeCamera.schedule();
 
     drive.setDefaultCommand(driveFieldOrientedHeadingSnapping);
+    compressor.setDefaultCommand(controlCompressor);
   }
 
   private void configureAuto() {

--- a/src/main/java/frc/robot/commands/ControlCompressor.java
+++ b/src/main/java/frc/robot/commands/ControlCompressor.java
@@ -12,12 +12,14 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.subsystems.Compressor;
 
 /** Keeps the compressor at the pressure the pressure switch looks for. */
 public class ControlCompressor extends Command {
   private Compressor compressor;
+  private int callsAtPressure = 0;
 
   /** Create a new ControlCompressor */
   public ControlCompressor() {
@@ -32,7 +34,12 @@ public class ControlCompressor extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    if (!compressor.isAtPressure()) {
+    if (compressor.isAtPressure()) {
+      callsAtPressure++;
+    } else {
+      callsAtPressure = Math.max(0, callsAtPressure - 1);
+    }
+    if (callsAtPressure < Constants.Compressor.COMPRESSOR_PRESSURE_SWITCH_DEADBAND) {
       compressor.activateCompressor();
     } else {
       compressor.disableCompressor();

--- a/src/main/java/frc/robot/commands/ControlCompressor.java
+++ b/src/main/java/frc/robot/commands/ControlCompressor.java
@@ -1,0 +1,53 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+/*
+ * Asimov's Laws:
+ * The First Law: A robot may not injure a human being or, through inaction, allow a human being to come to harm.
+ * The Second Law: A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
+ * The Third Law: A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+ */
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.RobotContainer;
+import frc.robot.subsystems.Compressor;
+
+/** Keeps the compressor at the pressure the pressure switch looks for. */
+public class ControlCompressor extends Command {
+  private Compressor compressor;
+
+  /** Create a new ControlCompressor */
+  public ControlCompressor() {
+    compressor = RobotContainer.compressor;
+    addRequirements(compressor);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    if (!compressor.isAtPressure()) {
+      compressor.activateCompressor();
+    } else {
+      compressor.disableCompressor();
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    compressor.disableCompressor();
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Compressor.java
+++ b/src/main/java/frc/robot/subsystems/Compressor.java
@@ -1,0 +1,64 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+/*
+ * Asimov's Laws:
+ * The First Law: A robot may not injure a human being or, through inaction, allow a human being to come to harm.
+ * The Second Law: A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
+ * The Third Law: A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+ */
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.Relay;
+import edu.wpi.first.wpilibj.Relay.Value;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
+
+/** The subsystem for the compressor */
+public class Compressor extends SubsystemBase {
+  private Relay compressorRelay;
+  private DigitalInput pressureSwitch;
+
+  /** Creates a new Compressor. */
+  public Compressor() {
+    this.compressorRelay = new Relay(Constants.Compressor.COMPRESSOR_RELAY_PORT);
+    this.pressureSwitch = new DigitalInput(Constants.Compressor.PRESSURE_SWITCH_DIO_PORT);
+  }
+
+  /**
+   * Activates the compressor.
+   *
+   * @return If the compressor was able to be turned on.
+   */
+  public boolean activateCompressor() {
+    if (this.pressureSwitch.get()) {
+      this.compressorRelay.set(Value.kForward);
+      return true;
+    } else {
+      System.err.println(
+          "Warning: Attempted to activate compressor while pressure switch activated");
+      disableCompressor();
+      return false;
+    }
+  }
+
+  /** Disables the compressor. */
+  public void disableCompressor() {
+    this.compressorRelay.set(Value.kOff);
+  }
+
+  /**
+   * Returns true if the compressor is at pressure. False otherwise.
+   *
+   * @return true if the compressor is at pressure. False otherwise.
+   */
+  public boolean isAtPressure() {
+    return !this.pressureSwitch.get();
+  }
+
+  @Override
+  public void periodic() {}
+}

--- a/src/main/java/frc/robot/subsystems/Compressor.java
+++ b/src/main/java/frc/robot/subsystems/Compressor.java
@@ -35,13 +35,12 @@ public class Compressor extends SubsystemBase {
    * @return If the compressor was able to be turned on.
    */
   public boolean activateCompressor() {
-    if (this.pressureSwitch.get()) {
+    if (!this.pressureSwitch.get()) {
       this.compressorRelay.set(Value.kForward);
       return true;
     } else {
       DriverStation.reportWarning(
           "Warning: Attempted to activate compressor while pressure switch activated", false);
-      disableCompressor();
       return false;
     }
   }
@@ -57,7 +56,7 @@ public class Compressor extends SubsystemBase {
    * @return true if the compressor is at pressure. False otherwise.
    */
   public boolean isAtPressure() {
-    return !this.pressureSwitch.get();
+    return this.pressureSwitch.get();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Compressor.java
+++ b/src/main/java/frc/robot/subsystems/Compressor.java
@@ -12,6 +12,7 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Relay;
 import edu.wpi.first.wpilibj.Relay.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -38,8 +39,8 @@ public class Compressor extends SubsystemBase {
       this.compressorRelay.set(Value.kForward);
       return true;
     } else {
-      System.err.println(
-          "Warning: Attempted to activate compressor while pressure switch activated");
+      DriverStation.reportWarning(
+          "Warning: Attempted to activate compressor while pressure switch activated", false);
       disableCompressor();
       return false;
     }
@@ -47,7 +48,7 @@ public class Compressor extends SubsystemBase {
 
   /** Disables the compressor. */
   public void disableCompressor() {
-    this.compressorRelay.set(Value.kOff);
+    this.compressorRelay.set(Relay.Value.kOff);
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
+++ b/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
@@ -20,31 +20,26 @@ import frc.robot.Constants;
  * our robot
  */
 public class MailboxPneumatics extends SubsystemBase {
-  private Relay leftRelay;
-  private Relay rightRelay;
+  private Relay pneumaticsRelay;
 
   /** Constructor for the mailbox pneumatics subsystem. */
   public MailboxPneumatics() {
-    leftRelay = new Relay(Constants.MailboxPneumatics.LEFT_SOLENOID_RELAY_ID);
-    rightRelay = new Relay(Constants.MailboxPneumatics.RIGHT_SOLENOID_RELAY_ID);
+    pneumaticsRelay = new Relay(Constants.MailboxPneumatics.MAILBOX_SOLENOID_RELAY_ID);
   }
 
   /** Lifts the mailbox. */
   public void extend() {
-    leftRelay.set(Relay.Value.kForward);
-    rightRelay.set(Relay.Value.kForward);
+    pneumaticsRelay.set(Relay.Value.kForward);
   }
 
   /** Lowers the mailbox. */
   public void retract() {
-    leftRelay.set(Relay.Value.kReverse);
-    rightRelay.set(Relay.Value.kReverse);
+    pneumaticsRelay.set(Relay.Value.kReverse);
   }
 
   /** Sets pistons to off */
   public void off() {
-    leftRelay.set(Relay.Value.kOff);
-    rightRelay.set(Relay.Value.kOff);
+    pneumaticsRelay.set(Relay.Value.kOff);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
+++ b/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
@@ -12,7 +12,6 @@
 package frc.robot.subsystems.mailbox;
 
 import edu.wpi.first.wpilibj.Relay;
-import edu.wpi.first.wpilibj.Relay.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
@@ -32,20 +31,20 @@ public class MailboxPneumatics extends SubsystemBase {
 
   /** Lifts the mailbox. */
   public void extend() {
-    leftRelay.set(Value.kForward);
-    rightRelay.set(Value.kForward);
+    leftRelay.set(Relay.Value.kForward);
+    rightRelay.set(Relay.Value.kForward);
   }
 
   /** Lowers the mailbox. */
   public void retract() {
-    leftRelay.set(Value.kReverse);
-    rightRelay.set(Value.kReverse);
+    leftRelay.set(Relay.Value.kReverse);
+    rightRelay.set(Relay.Value.kReverse);
   }
 
   /** Sets pistons to off */
   public void off() {
-    leftRelay.set(Value.kOff);
-    rightRelay.set(Value.kOff);
+    leftRelay.set(Relay.Value.kOff);
+    rightRelay.set(Relay.Value.kOff);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
+++ b/src/main/java/frc/robot/subsystems/mailbox/MailboxPneumatics.java
@@ -11,8 +11,8 @@
 
 package frc.robot.subsystems.mailbox;
 
-import edu.wpi.first.wpilibj.DoubleSolenoid;
-import edu.wpi.first.wpilibj.PneumaticsModuleType;
+import edu.wpi.first.wpilibj.Relay;
+import edu.wpi.first.wpilibj.Relay.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
@@ -21,39 +21,31 @@ import frc.robot.Constants;
  * our robot
  */
 public class MailboxPneumatics extends SubsystemBase {
-  private DoubleSolenoid leftPiston;
-  private DoubleSolenoid rightPiston;
+  private Relay leftRelay;
+  private Relay rightRelay;
 
   /** Constructor for the mailbox pneumatics subsystem. */
   public MailboxPneumatics() {
-    leftPiston =
-        new DoubleSolenoid(
-            PneumaticsModuleType.CTREPCM,
-            Constants.MailboxPneumatics.LEFT_SOLENOID_FORWARD_CHANNEL,
-            Constants.MailboxPneumatics.LEFT_SOLENOID_REVERSE_CHANNEL);
-    rightPiston =
-        new DoubleSolenoid(
-            PneumaticsModuleType.CTREPCM,
-            Constants.MailboxPneumatics.RIGHT_SOLENOID_FORWARD_CHANNEL,
-            Constants.MailboxPneumatics.RIGHT_SOLENOID_REVERSE_CHANNEL);
+    leftRelay = new Relay(Constants.MailboxPneumatics.LEFT_SOLENOID_RELAY_ID);
+    rightRelay = new Relay(Constants.MailboxPneumatics.RIGHT_SOLENOID_RELAY_ID);
   }
 
   /** Lifts the mailbox. */
   public void extend() {
-    leftPiston.set(DoubleSolenoid.Value.kForward);
-    rightPiston.set(DoubleSolenoid.Value.kForward);
+    leftRelay.set(Value.kForward);
+    rightRelay.set(Value.kForward);
   }
 
   /** Lowers the mailbox. */
   public void retract() {
-    leftPiston.set(DoubleSolenoid.Value.kReverse);
-    rightPiston.set(DoubleSolenoid.Value.kReverse);
+    leftRelay.set(Value.kReverse);
+    rightRelay.set(Value.kReverse);
   }
 
   /** Sets pistons to off */
   public void off() {
-    leftPiston.set(DoubleSolenoid.Value.kOff);
-    rightPiston.set(DoubleSolenoid.Value.kOff);
+    leftRelay.set(Value.kOff);
+    rightRelay.set(Value.kOff);
   }
 
   @Override


### PR DESCRIPTION
Updates the code for pneumatics to use Spike relays instead of a PCM. Closes #177 